### PR TITLE
Cross eyes and blinking

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -113,6 +113,8 @@ export default class GlasaExtension extends Extension {
     const IRIS_MOVE = 0.66;
     const IRIS_SIZE = 0.5;
     const EYEBROW_SCALE = 1.4;
+    const VARIABLE_RELIEF = 15;
+    const CROSS_EYE_SLOPE = 0.4;
 
     let eye_radius = 2 * halfsize / (1 + EYEBROW_SCALE);
     let eyebrow_radius = EYEBROW_SCALE * eye_radius;
@@ -124,7 +126,6 @@ export default class GlasaExtension extends Extension {
     let left_center_x = halfwidth - eye_radius;
     let right_center_x = halfwidth + eye_radius;
 
-    mouse_x -= area_x + halfwidth;
     mouse_x_l -= area_x + left_center_x;
     mouse_x_r -= area_x + right_center_x;
     mouse_y -= area_y + center_y;
@@ -140,10 +141,12 @@ export default class GlasaExtension extends Extension {
     let maxMouseDist_r = Math.sqrt(maxMouseDist_x_r * maxMouseDist_x_r +
       maxMouseDist_y * maxMouseDist_y);
 
-    let factor_left = Math.sqrt(mouse_x_l * mouse_x_l + mouse_y * mouse_y) /
-      (RELIEF_FACTOR * eye_radius);
-    let factor_right = Math.sqrt(mouse_x_r * mouse_x_r + mouse_y * mouse_y) /
-      (RELIEF_FACTOR * eye_radius);
+    let mouse_distance_l = Math.sqrt(mouse_x_l * mouse_x_l + mouse_y * mouse_y);
+    let mouse_distance_r = Math.sqrt(mouse_x_r * mouse_x_r + mouse_y * mouse_y);
+    let factor_left = mouse_distance_l / ((RELIEF_FACTOR + VARIABLE_RELIEF *
+      Math.pow(mouse_distance_l/maxMouseDist_l, CROSS_EYE_SLOPE)) * eye_radius);
+    let factor_right = mouse_distance_r / ((RELIEF_FACTOR + VARIABLE_RELIEF *
+      Math.pow(mouse_distance_r/maxMouseDist_r, CROSS_EYE_SLOPE)) * eye_radius);
     if (factor_left > RELIEF_FACTOR_BOUND) factor_left = RELIEF_FACTOR_BOUND;
     if (factor_right > RELIEF_FACTOR_BOUND) factor_right = RELIEF_FACTOR_BOUND;
     let iris_move_left = eye_radius * IRIS_MOVE * factor_left;

--- a/extension.js
+++ b/extension.js
@@ -103,6 +103,9 @@ export default class GlasaExtension extends Extension {
     let [mouse_x, mouse_y, mask] = global.get_pointer();
     let mouse_x_l = mouse_x;
     let mouse_x_r = mouse_x;
+    let rect = global.display.get_monitor_geometry(global.display.get_primary_monitor());
+    let geo_width = rect.width;
+    let geo_height = rect.height;
 
     const EYE_LINE_WIDTH = 1.5;
     const RELIEF_FACTOR = 2;
@@ -125,6 +128,17 @@ export default class GlasaExtension extends Extension {
     mouse_x_l -= area_x + left_center_x;
     mouse_x_r -= area_x + right_center_x;
     mouse_y -= area_y + center_y;
+
+    let maxMouseDist_y = geo_height - (area_y + center_y);
+    let maxMouseDist_x_l = area_y + left_center_x  > geo_width/2 ?
+      area_x + left_center_x  : geo_width-(area_x + left_center_x);
+    let maxMouseDist_x_r = area_y + right_center_x > geo_width/2 ?
+      area_x + right_center_x : geo_width-(area_x + right_center_x);
+
+    let maxMouseDist_l = Math.sqrt(maxMouseDist_x_l * maxMouseDist_x_l +
+      maxMouseDist_y * maxMouseDist_y);
+    let maxMouseDist_r = Math.sqrt(maxMouseDist_x_r * maxMouseDist_x_r +
+      maxMouseDist_y * maxMouseDist_y);
 
     let factor_left = Math.sqrt(mouse_x_l * mouse_x_l + mouse_y * mouse_y) /
       (RELIEF_FACTOR * eye_radius);

--- a/extension.js
+++ b/extension.js
@@ -101,6 +101,8 @@ export default class GlasaExtension extends Extension {
     let halfwidth = this._icon.width / 2;
     let [area_x, area_y] = this._icon.get_transformed_position();
     let [mouse_x, mouse_y, mask] = global.get_pointer();
+    let mouse_x_l = mouse_x;
+    let mouse_x_r = mouse_x;
 
     const EYE_LINE_WIDTH = 1.5;
     const RELIEF_FACTOR = 30;
@@ -120,12 +122,18 @@ export default class GlasaExtension extends Extension {
     let right_center_x = halfwidth + eye_radius;
 
     mouse_x -= area_x + halfwidth;
+    mouse_x_l -= area_x + left_center_x;
+    mouse_x_r -= area_x + right_center_x;
     mouse_y -= area_y + center_y;
 
-    let factor = Math.sqrt(mouse_x * mouse_x + mouse_y * mouse_y) /
+    let factor_left = Math.sqrt(mouse_x_l * mouse_x_l + mouse_y * mouse_y) /
       (RELIEF_FACTOR * eye_radius);
-    if (factor > RELIEF_FACTOR_BOUND) factor = RELIEF_FACTOR_BOUND;
-    let iris_move = eye_radius * IRIS_MOVE * factor;
+    let factor_right = Math.sqrt(mouse_x_r * mouse_x_r + mouse_y * mouse_y) /
+      (RELIEF_FACTOR * eye_radius);
+    if (factor_left > RELIEF_FACTOR_BOUND) factor_left = RELIEF_FACTOR_BOUND;
+    if (factor_right > RELIEF_FACTOR_BOUND) factor_right = RELIEF_FACTOR_BOUND;
+    let iris_move_left = eye_radius * IRIS_MOVE * factor_left;
+    let iris_move_right = eye_radius * IRIS_MOVE * factor_right;
 
     // Get and set up the Cairo context.
     let cr = this._icon.get_context();
@@ -143,9 +151,9 @@ export default class GlasaExtension extends Extension {
     cr.arc(0, 0, eyebrow_radius, 5 * Math.PI / 4, 6.5 * Math.PI / 4);
     cr.stroke();
     // Draw the left iris/pupil.
-    cr.rotate(Math.PI / 2 - Math.atan2(mouse_x, mouse_y));
-    cr.translate(iris_move, 0);
-    cr.scale(Math.cos(factor), 1);
+    cr.rotate(Math.PI / 2 - Math.atan2(mouse_x_l, mouse_y));
+    cr.translate(iris_move_left, 0);
+    cr.scale(Math.cos(factor_left), 1);
     cr.arc(0, 0, eye_radius * IRIS_SIZE, 0, 2 * Math.PI);
     cr.fill();
     cr.restore();
@@ -158,9 +166,9 @@ export default class GlasaExtension extends Extension {
     cr.arc(0, 0, eyebrow_radius, 5.5 * Math.PI / 4, 7 * Math.PI / 4);
     cr.stroke();
     // Draw the right iris/pupil.
-    cr.rotate(Math.PI / 2 - Math.atan2(mouse_x, mouse_y));
-    cr.translate(iris_move, 0);
-    cr.scale(Math.cos(factor), 1);
+    cr.rotate(Math.PI / 2 - Math.atan2(mouse_x_r, mouse_y));
+    cr.translate(iris_move_right, 0);
+    cr.scale(Math.cos(factor_right), 1);
     cr.arc(0, 0, eye_radius * IRIS_SIZE, 0, 2 * Math.PI);
     cr.fill();
     cr.restore();

--- a/extension.js
+++ b/extension.js
@@ -105,7 +105,7 @@ export default class GlasaExtension extends Extension {
     let mouse_x_r = mouse_x;
 
     const EYE_LINE_WIDTH = 1.5;
-    const RELIEF_FACTOR = 30;
+    const RELIEF_FACTOR = 2;
     const RELIEF_FACTOR_BOUND = 0.7;
     const IRIS_MOVE = 0.66;
     const IRIS_SIZE = 0.5;

--- a/extension.js
+++ b/extension.js
@@ -119,7 +119,7 @@ export default class GlasaExtension extends Extension {
     let left_center_x = halfwidth - eye_radius;
     let right_center_x = halfwidth + eye_radius;
 
-    mouse_x -= area_x + 2 * halfsize;
+    mouse_x -= area_x + halfwidth;
     mouse_y -= area_y + center_y;
 
     let factor = Math.sqrt(mouse_x * mouse_x + mouse_y * mouse_y) /


### PR DESCRIPTION
As per a [request of user acerspyro](https://extensions.gnome.org/extension/4780/glasa/) on the Gnome extension page, I've added a slight cross eye effect.

It works by adding a variable relief factor to the (reduced) constant relief as a function of the pointer-widget distance. The slope of the function can be adjusted via its exponent. I've set all parameters to my personal preferences. Feel free to adjust them as you wish ofc. Setting the exponent to $0.0$ removes the cross eye effect. Setting it to $1.0$ adds a very comical effect of each eye following the pointer very closely.

I also added random blinking for some liveliness. That seems to me that ups my productivity, as it draws my attention to the screen after going astray.
The PR also removes some duplicated eye drawing logic.